### PR TITLE
Fix terraform-docs error "cannot execute binary file: Exec format error"

### DIFF
--- a/terraform-docs-bin/PKGBUILD
+++ b/terraform-docs-bin/PKGBUILD
@@ -14,5 +14,5 @@ sha256sums=('f0a46b13c126f06eba44178f901bb7b6b5f61a8b89e07a88988c6f45e5fcce19')
 
 package() {
   cd "${srcdir}"
-  install -Dm755 ${srcdir}/${_name}-${pkgver} ${pkgdir}/usr/bin/${_name}
+  install -Dm755 ${srcdir}/${_name} ${pkgdir}/usr/bin/${_name}
 }


### PR DESCRIPTION
Recently after updating `terraform-docs` using the `terraform-docs-bin` AUR package, I got the following error when trying to run `terraform-docs`:

```
bash: /usr/bin/terraform-docs: cannot execute binary file: Exec format error
```

I admit I'm not a `PKGBUILD` expert, and I don't know why it all of a sudden stopped working, because it worked before.  However, after some troubleshooting, I noticed that the binary file inside the `.tar.gz` release is simply named `terraform-docs` whereas the `PKGBUILD` appears to look for a file named like `terraform-docs-0.14.1`.  The latter file does exist after running `makepkg` even though it's not part of the release archive, but it's apparently not executable.  It's a link to a file of the same name outside the `src` directory.

Anyways, I was able to get it working on my system by making this adjustment to the `PKGBUILD`.